### PR TITLE
Vlan endpoint support in kata-runtime

### DIFF
--- a/virtcontainers/endpoint.go
+++ b/virtcontainers/endpoint.go
@@ -37,7 +37,7 @@ const (
 	VethEndpointType EndpointType = "virtual"
 
 	// VlanEndpointType is the virtual network interface.
-	VlanEndpointType EndpointType = "virtual"
+	VlanEndpointType EndpointType = "vlan"
 
 	// VhostUserEndpointType is the vhostuser network interface.
 	VhostUserEndpointType EndpointType = "vhost-user"
@@ -76,6 +76,9 @@ func (endpointType *EndpointType) Set(value string) error {
 	case "tap":
 		*endpointType = TapEndpointType
 		return nil
+	case "vlan":
+		*endpointType = VlanEndpointType
+		return nil
 	case "ipvlan":
 		*endpointType = IPVlanEndpointType
 		return nil
@@ -99,6 +102,8 @@ func (endpointType *EndpointType) String() string {
 		return string(MacvtapEndpointType)
 	case TapEndpointType:
 		return string(TapEndpointType)
+	case VlanEndpointType:
+		return string(VlanEndpointType)
 	case IPVlanEndpointType:
 		return string(IPVlanEndpointType)
 	default:

--- a/virtcontainers/endpoint.go
+++ b/virtcontainers/endpoint.go
@@ -36,6 +36,9 @@ const (
 	// VethEndpointType is the virtual network interface.
 	VethEndpointType EndpointType = "virtual"
 
+	// VlanEndpointType is the virtual network interface.
+	VlanEndpointType EndpointType = "virtual"
+
 	// VhostUserEndpointType is the vhostuser network interface.
 	VhostUserEndpointType EndpointType = "vhost-user"
 

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -532,28 +532,26 @@ func (k *kataAgent) updateInterfaces(interfaces []*vcTypes.Interface) error {
 }
 
 func (k *kataAgent) updateRoutes(routes []*vcTypes.Route) ([]*vcTypes.Route, error) {
-	// XXX Remove me
-	/*
-		if routes != nil {
-			routesReq := &grpc.UpdateRoutesRequest{
-				Routes: &grpc.Routes{
-					Routes: k.convertToKataAgentRoutes(routes),
-				},
-			}
-			resultingRoutes, err := k.sendReq(routesReq)
-			if err != nil {
-				k.Logger().WithFields(logrus.Fields{
-					"routes-requested": fmt.Sprintf("%+v", routes),
-					"resulting-routes": fmt.Sprintf("%+v", resultingRoutes),
-				}).WithError(err).Error("update routes request failed")
-			}
-			resultRoutes, ok := resultingRoutes.(*grpc.Routes)
-			if ok && resultRoutes != nil {
-				return k.convertToRoutes(resultRoutes.Routes), err
-			}
-			return nil, err
+	routes = append(routes[:2], routes[3:]...)
+	if routes != nil {
+		routesReq := &grpc.UpdateRoutesRequest{
+			Routes: &grpc.Routes{
+				Routes: k.convertToKataAgentRoutes(routes),
+			},
 		}
-	*/
+		resultingRoutes, err := k.sendReq(routesReq)
+		if err != nil {
+			k.Logger().WithFields(logrus.Fields{
+				"routes-requested": fmt.Sprintf("%+v", routes),
+				"resulting-routes": fmt.Sprintf("%+v", resultingRoutes),
+			}).WithError(err).Error("update routes request failed")
+		}
+		resultRoutes, ok := resultingRoutes.(*grpc.Routes)
+		if ok && resultRoutes != nil {
+			return k.convertToRoutes(resultRoutes.Routes), err
+		}
+		return nil, err
+	}
 	return nil, nil
 }
 

--- a/virtcontainers/kata_agent.go
+++ b/virtcontainers/kata_agent.go
@@ -532,25 +532,28 @@ func (k *kataAgent) updateInterfaces(interfaces []*vcTypes.Interface) error {
 }
 
 func (k *kataAgent) updateRoutes(routes []*vcTypes.Route) ([]*vcTypes.Route, error) {
-	if routes != nil {
-		routesReq := &grpc.UpdateRoutesRequest{
-			Routes: &grpc.Routes{
-				Routes: k.convertToKataAgentRoutes(routes),
-			},
+	// XXX Remove me
+	/*
+		if routes != nil {
+			routesReq := &grpc.UpdateRoutesRequest{
+				Routes: &grpc.Routes{
+					Routes: k.convertToKataAgentRoutes(routes),
+				},
+			}
+			resultingRoutes, err := k.sendReq(routesReq)
+			if err != nil {
+				k.Logger().WithFields(logrus.Fields{
+					"routes-requested": fmt.Sprintf("%+v", routes),
+					"resulting-routes": fmt.Sprintf("%+v", resultingRoutes),
+				}).WithError(err).Error("update routes request failed")
+			}
+			resultRoutes, ok := resultingRoutes.(*grpc.Routes)
+			if ok && resultRoutes != nil {
+				return k.convertToRoutes(resultRoutes.Routes), err
+			}
+			return nil, err
 		}
-		resultingRoutes, err := k.sendReq(routesReq)
-		if err != nil {
-			k.Logger().WithFields(logrus.Fields{
-				"routes-requested": fmt.Sprintf("%+v", routes),
-				"resulting-routes": fmt.Sprintf("%+v", resultingRoutes),
-			}).WithError(err).Error("update routes request failed")
-		}
-		resultRoutes, ok := resultingRoutes.(*grpc.Routes)
-		if ok && resultRoutes != nil {
-			return k.convertToRoutes(resultRoutes.Routes), err
-		}
-		return nil, err
-	}
+	*/
 	return nil, nil
 }
 

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -262,6 +262,10 @@ func generateEndpoints(typedEndpoints []TypedJSONEndpoint) ([]Endpoint, error) {
 			var endpoint IPVlanEndpoint
 			endpointInf = &endpoint
 
+		case VlanEndpointType:
+			var endpoint VlanEndpoint
+			endpointInf = &endpoint
+
 		default:
 			networkLogger().WithField("endpoint-type", e.Type).Error("Ignoring unknown endpoint type")
 		}
@@ -373,6 +377,8 @@ func getLinkForEndpoint(endpoint Endpoint, netHandle *netlink.Handle) (netlink.L
 		link = &netlink.Macvlan{}
 	case *IPVlanEndpoint:
 		link = &netlink.IPVlan{}
+	case *VlanEndpoint:
+		link = &netlink.Vlan{}
 	default:
 		return nil, fmt.Errorf("Unexpected endpointType %s", ep.Type())
 	}
@@ -387,6 +393,10 @@ func getLinkByName(netHandle *netlink.Handle, name string, expectedLink netlink.
 	}
 
 	switch expectedLink.Type() {
+	case (&netlink.Vlan{}).Type():
+		if l, ok := link.(*netlink.Vlan); ok {
+			return l, nil
+		}
 	case (&netlink.Bridge{}).Type():
 		if l, ok := link.(*netlink.Bridge); ok {
 			return l, nil

--- a/virtcontainers/network.go
+++ b/virtcontainers/network.go
@@ -1380,10 +1380,12 @@ func createEndpoint(netInfo NetworkInfo, idx int, model NetInterworkingModel) (E
 			endpoint, err = createTapNetworkEndpoint(idx, netInfo.Iface.Name)
 		} else if netInfo.Iface.Type == "veth" {
 			endpoint, err = createVethNetworkEndpoint(idx, netInfo.Iface.Name, model)
+		} else if netInfo.Iface.Type == "vlan" {
+			endpoint, err = createVlanNetworkEndpoint(idx, netInfo.Iface.Name, model)
 		} else if netInfo.Iface.Type == "ipvlan" {
 			endpoint, err = createIPVlanNetworkEndpoint(idx, netInfo.Iface.Name)
 		} else {
-			return nil, fmt.Errorf("Unsupported network interface")
+			return nil, fmt.Errorf("unsupported network interface, type:%s, model:%v", netInfo.Iface.Type, model)
 		}
 	}
 

--- a/virtcontainers/qemu_arch_base.go
+++ b/virtcontainers/qemu_arch_base.go
@@ -454,7 +454,7 @@ func networkModelToQemuType(model NetInterworkingModel) govmmQemu.NetDeviceType 
 
 func (q *qemuArchBase) appendNetwork(devices []govmmQemu.Device, endpoint Endpoint) []govmmQemu.Device {
 	switch ep := endpoint.(type) {
-	case *VethEndpoint, *BridgedMacvlanEndpoint, *IPVlanEndpoint:
+	case *VlanEndpoint, *VethEndpoint, *BridgedMacvlanEndpoint, *IPVlanEndpoint:
 		netPair := ep.NetworkPair()
 		devices = append(devices,
 			govmmQemu.NetDevice{

--- a/virtcontainers/vlan_endpoint.go
+++ b/virtcontainers/vlan_endpoint.go
@@ -1,0 +1,80 @@
+package virtcontainers
+
+import "fmt"
+
+// VlanEndpoint gathers a network pair and its properties.
+type VlanEndpoint struct {
+	NetPair            NetworkInterfacePair
+	EndpointProperties NetworkInfo
+	EndpointType       EndpointType
+	// todo: vlan id, how does this differ from pciaddress? how is it used?
+	VlanId  int
+	PCIAddr string
+}
+
+func createVlanNetworkEndpoint(idx int, ifName string, interworkingModel NetInterworkingModel) (*VlanEndpoint, error) {
+	return nil, fmt.Errorf("vlan net endpoint is not implemented")
+}
+
+// Properties returns properties for the vlan interface in the network pair.
+func (endpoint *VlanEndpoint) Properties() NetworkInfo {
+	return endpoint.EndpointProperties
+}
+
+// Name returns name of the vlan interface in the network pair.
+func (endpoint *VlanEndpoint) Name() string {
+	return endpoint.NetPair.VirtIface.Name
+}
+
+// HardwareAddr returns the mac address that is assigned to the tap interface
+// in th network pair.
+func (endpoint *VlanEndpoint) HardwareAddr() string {
+	return endpoint.NetPair.TAPIface.HardAddr
+}
+
+// Type identifies the endpoint as a vlan endpoint.
+func (endpoint *VlanEndpoint) Type() EndpointType {
+	return endpoint.EndpointType
+}
+
+// PciAddr returns the PCI address of the endpoint.
+func (endpoint *VlanEndpoint) PciAddr() string {
+	return endpoint.PCIAddr
+}
+
+// SetPciAddr sets the PCI address of the endpoint.
+func (endpoint *VlanEndpoint) SetPciAddr(pciAddr string) {
+	endpoint.PCIAddr = pciAddr
+}
+
+// NetworkPair returns the network pair of the endpoint.
+func (endpoint *VlanEndpoint) NetworkPair() *NetworkInterfacePair {
+	return &endpoint.NetPair
+}
+
+// SetProperties sets the properties for the endpoint.
+func (endpoint *VlanEndpoint) SetProperties(properties NetworkInfo) {
+	endpoint.EndpointProperties = properties
+}
+
+// Attach for vlan endpoint bridges the network pair and adds the
+// tap interface of the network pair to the hypervisor.
+func (endpoint *VlanEndpoint) Attach(hypervisor) error {
+	return fmt.Errorf("attach for vlan endpoint is not yet implemented")
+}
+
+// Detach for the vlan endpoint tears down the tap and bridge
+// created for the vlan interface.
+func (endpoint *VlanEndpoint) Detach(netNsCreated bool, netNsPath string) error {
+	return fmt.Errorf("detach for vlan endpoint is not yet implemented")
+}
+
+// HotAttach for the vlan endpoint uses hot plug device
+func (endpoint *VlanEndpoint) HotAttach(h hypervisor) error {
+	return fmt.Errorf("hot attach for vlan endpoint is not yet implemented")
+}
+
+// HotDetach for the vlan endpoint uses hot pull device
+func (endpoint *VlanEndpoint) HotDetach(h hypervisor, netNsCreated bool, netNsPath string) error {
+	return fmt.Errorf("hot detach for vlan endpoint is not yet implemented")
+}


### PR DESCRIPTION
Support for VlanEndpoint in kata runtime. 


```
-bash-4.2$ kubectl logs iperf-serverhigh1
------------------------------------------------------------
Server listening on TCP port 5001
TCP window size: 85.3 KByte (default)
------------------------------------------------------------
[  4] local 172.16.194.4 port 5001 connected with 172.16.194.5 port 38525
[  5] local 172.16.194.4 port 5001 connected with 172.16.194.5 port 38538
[  6] local 172.16.194.4 port 5001 connected with 172.16.194.5 port 38524
[  7] local 172.16.194.4 port 5001 connected with 172.16.194.5 port 38528
[  8] local 172.16.194.4 port 5001 connected with 172.16.194.5 port 38533
[  9] local 172.16.194.4 port 5001 connected with 172.16.194.5 port 38530
[ 10] local 172.16.194.4 port 5001 connected with 172.16.194.5 port 38532
[ 11] local 172.16.194.4 port 5001 connected with 172.16.194.5 port 38534
[ ID] Interval       Transfer     Bandwidth
[  4]  0.0-20.0 sec  2.38 GBytes  1.02 Gbits/sec
[  5]  0.0-20.0 sec  6.19 GBytes  2.66 Gbits/sec
[  7]  0.0-20.0 sec  2.66 GBytes  1.14 Gbits/sec
[  8]  0.0-20.0 sec  4.93 GBytes  2.12 Gbits/sec
[  9]  0.0-20.0 sec  1.46 GBytes   625 Mbits/sec
[ 10]  0.0-20.0 sec  1.30 GBytes   558 Mbits/sec
[ 11]  0.0-20.0 sec  1.13 GBytes   485 Mbits/sec
[  6]  0.0-20.0 sec  1.79 GBytes   769 Mbits/sec
[SUM]  0.0-20.0 sec  21.8 GBytes  9.37 Gbits/sec


-bash-4.2$ kubectl get pods
NAME                READY   STATUS    RESTARTS   AGE
iperf-clienthigh1   1/1     Running   0          22s
iperf-serverhigh1   1/1     Running   0          26s
-bash-4.2$ kubectl logs iperf-clienthigh1
WARNING: attempt to set TCP maximum segment size to 1454, but got 536
WARNING: attempt to set TCP maximum segment size to 1454, but got 536
WARNING: attempt to set TCP maximum segment size to 1454, but got 536
WARNING: attempt to set TCP maximum segment size to 1454, but got 536
WARNING: attempt to set TCP maximum segment size to 1454, but got 536
WARNING: attempt to set TCP maximum segment size to 1454, but got 536
WARNING: attempt to set TCP maximum segment size to 1454, but got 536
WARNING: attempt to set TCP maximum segment size to 1454, but got 536
------------------------------------------------------------
Client connecting to iperf-serverhigh1, TCP port 5001
TCP window size: 45.0 KByte (default)
------------------------------------------------------------
[  6] local 172.16.194.5 port 38525 connected with 172.16.194.4 port 5001
[  4] local 172.16.194.5 port 38524 connected with 172.16.194.4 port 5001
[  8] local 172.16.194.5 port 38530 connected with 172.16.194.4 port 5001
[  5] local 172.16.194.5 port 38533 connected with 172.16.194.4 port 5001
[ 10] local 172.16.194.5 port 38528 connected with 172.16.194.4 port 5001
[  9] local 172.16.194.5 port 38538 connected with 172.16.194.4 port 5001
[  7] local 172.16.194.5 port 38532 connected with 172.16.194.4 port 5001
[  3] local 172.16.194.5 port 38534 connected with 172.16.194.4 port 5001
[ ID] Interval       Transfer     Bandwidth
[  6]  0.0- 5.0 sec   488 MBytes   818 Mbits/sec
[  4]  0.0- 5.0 sec  1.33 GBytes  2.29 Gbits/sec
[  8]  0.0- 5.0 sec   543 MBytes   911 Mbits/sec
[ 10]  0.0- 5.0 sec   578 MBytes   970 Mbits/sec
[  9]  0.0- 5.0 sec  1.36 GBytes  2.34 Gbits/sec
[  3]  0.0- 5.0 sec   283 MBytes   474 Mbits/sec
[  5]  0.0- 5.0 sec   730 MBytes  1.22 Gbits/sec
[  7]  0.0- 5.0 sec   212 MBytes   355 Mbits/sec
[SUM]  0.0- 5.0 sec  5.46 GBytes  9.39 Gbits/sec
[  6]  5.0-10.0 sec   554 MBytes   930 Mbits/sec
[  8]  5.0-10.0 sec   336 MBytes   564 Mbits/sec
[  5]  5.0-10.0 sec  1.20 GBytes  2.06 Gbits/sec
[ 10]  5.0-10.0 sec   650 MBytes  1.09 Gbits/sec
[  9]  5.0-10.0 sec  1.61 GBytes  2.76 Gbits/sec
[  7]  5.0-10.0 sec   362 MBytes   607 Mbits/sec
[  3]  5.0-10.0 sec   334 MBytes   561 Mbits/sec


\-bash-4.2$ kubectl get pods
NAME                READY   STATUS    RESTARTS   AGE
iperf-clienthigh1   1/1     Running   0          2m26s
iperf-serverhigh1   1/1     Running   0          2m30s
-bash-4.2$ kubectl get pods -o wide
NAME                READY   STATUS    RESTARTS   AGE     IP             NODE       NOMINATED NODE   READINESS GATES
iperf-clienthigh1   1/1     Running   0          2m35s   172.16.194.5   ltsserv6   <none>           <none>
iperf-serverhigh1   1/1     Running   0          2m39s   172.16.194.4   ltsserv5   <none>           <none>
-bash-4.2$
```